### PR TITLE
fix: add config directory to workflow paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ on:
       - "package.json"
       - "tests/**"
       - "template/**"
+      - "config/**"
       - "bin/**"
 
 jobs:


### PR DESCRIPTION
This pull request makes a minor update to the workflow trigger configuration in `.github/workflows/publish.yml`. The change ensures that updates to the `config` directory will now trigger the workflow as intended.